### PR TITLE
feat(macos): add RTF_IFSCOPE support for interface-scoped routes

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -33,6 +33,8 @@ pub struct Route {
     pub(crate) metric: Option<u32>,
     #[cfg(target_os = "windows")]
     pub(crate) luid: Option<u64>,
+    #[cfg(target_os = "macos")]
+    pub(crate) if_scope: bool,
 }
 impl Route {
     pub fn destination(&self) -> IpAddr {
@@ -79,6 +81,11 @@ impl Route {
     pub fn luid(&self) -> Option<u64> {
         self.luid
     }
+    /// (macOS only) Returns whether RTF_IFSCOPE is enabled for this route.
+    #[cfg(target_os = "macos")]
+    pub fn if_scope(&self) -> bool {
+        self.if_scope
+    }
 }
 impl Route {
     pub fn new(destination: IpAddr, prefix: u8) -> Self {
@@ -105,6 +112,8 @@ impl Route {
             metric: None,
             #[cfg(target_os = "windows")]
             luid: None,
+            #[cfg(target_os = "macos")]
+            if_scope: false,
         }
     }
     /// Sets the gateway (next hop) for the route.
@@ -159,6 +168,15 @@ impl Route {
         self.luid = Some(luid);
         self
     }
+    /// (macOS only) Enables or disables RTF_IFSCOPE, binding the route to the
+    /// interface specified via [`with_if_index`](Self::with_if_index) /
+    /// [`with_if_name`](Self::with_if_name). When enabled, route lookups are
+    /// scoped to that interface. Defaults to `false`.
+    #[cfg(target_os = "macos")]
+    pub fn with_if_scope(mut self, if_scope: bool) -> Self {
+        self.if_scope = if_scope;
+        self
+    }
 }
 impl Route {
     pub fn check(&self) -> io::Result<()> {
@@ -184,6 +202,12 @@ impl Route {
                     return Err(io::Error::other("if_index mismatch"));
                 }
             }
+        }
+        #[cfg(target_os = "macos")]
+        if self.if_scope && self.get_index().is_none() {
+            return Err(io::Error::other(
+                "if_scope requires an interface (if_index or if_name)",
+            ));
         }
         Ok(())
     }
@@ -331,6 +355,11 @@ impl fmt::Display for Route {
                 Some(l) => write!(f, "{l}"),
                 None => write!(f, "None"),
             }?;
+        }
+
+        #[cfg(target_os = "macos")]
+        if self.if_scope {
+            write!(f, ", if_scope: true")?;
         }
 
         #[cfg(target_os = "linux")]

--- a/src/unix_bsd/mod.rs
+++ b/src/unix_bsd/mod.rs
@@ -215,6 +215,11 @@ fn add_or_del_route_req(route: &Route, rtm_type: u8) -> io::Result<m_rtmsg> {
         rtm_flags |= RTF_HOST;
     }
 
+    #[cfg(target_os = "macos")]
+    if route.if_scope {
+        rtm_flags |= RTF_IFSCOPE;
+    }
+
     let mut rtm_addrs = RTA_DST | RTA_NETMASK;
     if rtm_type == RTM_ADD as u8 || route.gateway.is_some() {
         rtm_addrs |= RTA_GATEWAY;
@@ -292,6 +297,12 @@ fn route_to_m_rtmsg(_rtm_type: u8, value: &Route) -> io::Result<m_rtmsg> {
     #[cfg(target_os = "openbsd")]
     {
         rtmsg.hdr.rtm_hdrlen = std::mem::size_of::<rt_msghdr>() as u16;
+    }
+    #[cfg(target_os = "macos")]
+    if value.if_scope {
+        if let Some(idx) = if_index {
+            rtmsg.hdr.rtm_index = idx as u_short;
+        }
     }
     rtmsg.hdr.rtm_msglen = msg_len as u16;
     Ok(rtmsg)
@@ -531,6 +542,9 @@ fn message_to_route(hdr: &rt_msghdr, msg: &[u8]) -> Option<Route> {
         }
     }
 
+    #[cfg(target_os = "macos")]
+    let if_scope = hdr.rtm_flags as u32 & RTF_IFSCOPE != 0;
+
     Some(Route {
         destination,
         prefix,
@@ -539,6 +553,8 @@ fn message_to_route(hdr: &rt_msghdr, msg: &[u8]) -> Option<Route> {
         pref_source,
         if_name: if_index_to_name(hdr.rtm_index as u32).ok(),
         if_index: Some(hdr.rtm_index as u32),
+        #[cfg(target_os = "macos")]
+        if_scope,
     })
 }
 


### PR DESCRIPTION
Add an opt-in with_if_scope(bool) builder on macOS to bind a route to a specific interface (equivalent to `route -ifscope`). When enabled, the route message sets RTF_IFSCOPE and rtm_index to the configured interface index, scoping lookups to that interface.

- Route: new if_scope field (defaults to false), with_if_scope builder, if_scope() getter; check() requires an interface when if_scope is set
- unix_bsd: set RTF_IFSCOPE flag and rtm_index on add/delete; parse the flag back from the kernel in message_to_route so list/listen reflect it
- Display only mentions if_scope when true, keeping default output unchanged

Gated entirely behind cfg(target_os = "macos"); no impact on other platforms or existing behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS support for interface-scoped routing.
  * Routes can now explicitly target a network interface and preserve this setting when retrieved.

* **Bug Fixes**
  * Added validation to prevent interface-scoped routes from being created without an available interface.
  * Improved route details to indicate when interface scoping is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->