### PR TITLE
ci: upgrade FreeBSD runner to 13.5

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,7 @@ jobs:
           operating_system: freebsd
           environment_variables: TARGET
           architecture: x86-64
-          version: 13.2
+          version: 13.5
           shell: bash
           memory: 5G
           cpu_count: 4


### PR DESCRIPTION
## What changed

- Upgrade the FreeBSD CI VM from 13.2 to 13.5.

## Why

The latest stable Rust toolchain currently installed by `rustup` cannot run on the FreeBSD 13.2 image. Both `cargo` and `rustc` fail at startup with:

```text
Undefined symbol "__libc_start1@FBSD_1.7"
```

This is an operating-system libc compatibility failure that occurs before the project is compiled. FreeBSD 13.5 is supported by `cross-platform-actions/action@v0.28.0` and provides a newer userland compatible with the toolchain.

## Impact

Restores the FreeBSD CI job without changing library code or behavior.

## Validation

- Confirmed the branch differs from `main` by one workflow line only.
- GitHub Actions will validate the updated FreeBSD job on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the FreeBSD build environment to version 13.5 for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->